### PR TITLE
Install node-red-contrib-home-assistant by default

### DIFF
--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /usr/src/node-red
 USER root
 
 RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/* && apt-get clean
-RUN cd /data && npm install node-red-contrib-home-assistant
 
 # Expose tcp/1880
 EXPOSE 1880

--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/node-red
 
 USER root
 
-RUN apt-get update && apt-get install -y jq
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/* && apt-get clean
 RUN cd /data && npm install node-red-contrib-home-assistant
 
 # Expose tcp/1880

--- a/node-red/Dockerfile
+++ b/node-red/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /usr/src/node-red
 USER root
 
 RUN apt-get update && apt-get install -y jq
+RUN cd /data && npm install node-red-contrib-home-assistant
 
 # Expose tcp/1880
 EXPOSE 1880

--- a/node-red/run.sh
+++ b/node-red/run.sh
@@ -22,5 +22,8 @@ else
     sed -i "s/.*cert: fs.readFileSync/    \/\/    cert: fs.readFileSync/g" /data/settings.js
 fi
 
+[ -d /data/node_modules/node-red-contrib-home-assistant ] || { \
+    cd /data && npm install node-red-contrib-home-assistant ; }
+
 cd /usr/src/node-red
 npm start -- --userDir /data


### PR DESCRIPTION
This is a change that installs additional module node-red-contrib-home-assistant by default.
(I believe it has a lot of sense to have a pre-baked solution how to talk to home assistant from node-red
in this hassio addon)

https://www.npmjs.com/package/node-red-contrib-home-assistant
